### PR TITLE
Fixed Email Link

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -164,7 +164,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
               <paper-material elevation="1">
                 <div class="paper-font-body1">
-                  Email: <paper-button><a href="mailto://plusCubed@gmail.com">plusCubed@gmail.com</a></paper-button><br/>
+                  Email: <paper-button><a href="mailto:plusCubed@gmail.com">plusCubed@gmail.com</a></paper-button><br/>
                 </div>
               </paper-material>
 


### PR DESCRIPTION
Removed `//` from `mailto://plusCubed@gmail.com`
